### PR TITLE
Fix typo in Storey–Tibshirani method function name and its import

### DIFF
--- a/kgwas/eval_utils.py
+++ b/kgwas/eval_utils.py
@@ -536,7 +536,7 @@ def storey_pi_estimator(gwas_data, bin_index):
         pi0_est = 1
     return pi0_est
 
-def storey_ribshirani_integrate(gwas_data, column = 'pred', num_bins = 100):
+def storey_tibshirani_integrate(gwas_data, column = 'pred', num_bins = 100):
     num_bins = float(num_bins)
     quantiles = np.arange(0, 1 + 1 / (num_bins+1), 1 / num_bins)
     predicted_tagged_variance_quantiles = gwas_data[column].quantile(quantiles)

--- a/kgwas/kgwas.py
+++ b/kgwas/kgwas.py
@@ -18,7 +18,7 @@ from .utils import print_sys, compute_metrics, save_dict, \
                         load_dict, load_pretrained, save_model, \
                         evaluate_minibatch_clean, process_data, \
                         get_network_weight, generate_viz
-from .eval_utils import storey_ribshirani_integrate, get_clumps_gold_label, get_meta_clumps, \
+from .eval_utils import storey_tibshirani_integrate, get_clumps_gold_label, get_meta_clumps, \
                         get_mega_clump_query, get_curve, find_closest_x
 from .model import HeteroGNN
 


### PR DESCRIPTION
This PR corrects a typo in the function name implementing the Storey–Tibshirani method for estimating π₀:

 - Renames `storey_ribshirani_integrate` → `storey_tibshirani_integrate` in `eval_utils.py`
 - Updates corresponding import in `kgwas.py`

No functional changes were made—this update improves the clarity and correctness of naming.